### PR TITLE
Fix logger DI in BrevoEmailService

### DIFF
--- a/API/Services/BrevoEmailService.cs
+++ b/API/Services/BrevoEmailService.cs
@@ -11,9 +11,10 @@ namespace API.Services
         private readonly IConfiguration _configuration;
         private readonly ILogger<BrevoEmailService> _logger;
 
-        public BrevoEmailService(IConfiguration configuration)
+        public BrevoEmailService(IConfiguration configuration, ILogger<BrevoEmailService> logger)
         {
             _configuration = configuration;
+            _logger = logger;
         }
 
         public async Task SendEmailAsync(string receiverEmail, string subject, string htmlMessage)


### PR DESCRIPTION
## Summary
- inject `ILogger<BrevoEmailService>` into constructor

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403ef018dc832eaa5deba92c942029