### PR TITLE
Enforce pull requests for main branch

### DIFF
--- a/.github/workflows/require-pull-request.yml
+++ b/.github/workflows/require-pull-request.yml
@@ -1,0 +1,16 @@
+name: Prevent Direct Pushes to Main
+on:
+  push:
+    branches:
+      - main
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if commit is not from pull request
+        run: |
+          if [[ ! "${{ github.event.head_commit.message }}" =~ ^Merge\ pull\ request ]]; then
+            echo "Direct pushes to main are not allowed. Use a pull request."
+            exit 1
+          fi
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# CinemaBookingTicket
+
+This repository contains the source code for the CinemaBookingTicket project.
+
+## Branch policy
+
+The `main` branch is protected from direct pushes. All changes must be submitted through a pull request.
+
+A GitHub Actions workflow (`.github/workflows/require-pull-request.yml`) enforces this rule by failing if a commit is pushed directly to `main` without going through a pull request.
+
+To collaborate, create a feature branch and open a pull request targeting `main`.
+


### PR DESCRIPTION
## Summary
- add a README with branching policy
- add workflow that fails on direct pushes to main

## Testing
- `dotnet test` *(fails: `dotnet` not found)*
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68405e015d98832e9b1844079b0371ba